### PR TITLE
Fixed Versioning Compatibility for Many Mods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.16.5
 forge_version=36.1.4
 mod_version=0.1.7
 
-mekanism_version=1.16.5-10.0.21.448
+mekanism_version=10.0.21.448
 curios_version=1.16.5-4.0.5.0
 autoreglib_version=1.6-47.87
 patchouli_version=1.16.4-50

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -77,7 +77,7 @@ Legendary scythes are now avaible also for Forge modloader!
 
      mandatory=false
 
-     versionRange="[1.16.5-0.4.52,)"
+     versionRange="[0.4.52,)"
 
      ordering="AFTER"
 
@@ -89,7 +89,7 @@ Legendary scythes are now avaible also for Forge modloader!
 
      mandatory=false
 
-     versionRange="[1.16.5-10.0.21.448,)"
+     versionRange="[10.0.21.448,)"
 
      ordering="AFTER"
 
@@ -101,7 +101,7 @@ Legendary scythes are now avaible also for Forge modloader!
 
      mandatory=false
 
-     versionRange="[1.16.5-10.0.21.448,)"
+     versionRange="[10.0.21.448,)"
 
      ordering="AFTER"
 
@@ -137,7 +137,7 @@ Legendary scythes are now avaible also for Forge modloader!
 
      mandatory=false
 
-     versionRange="[1.16.5-0.4.5,)"
+     versionRange="[0.4.5,)"
 
      ordering="AFTER"
 


### PR DESCRIPTION
### Resolved #2

[Druidcraft](https://www.curseforge.com/minecraft/mc-mods/druidcraft)'s latest version (**0.4.52**) as defined in its [mods.toml](https://github.com/MysticMods/Druidcraft/blob/master/src/main/resources/META-INF/mods.toml) did not fit the version range provided by *Scythd*'s [mods.toml](https://github.com/lunekiska/Scythd/blob/main/src/main/resources/META-INF/mods.toml) (**1.16.5-0.4.52**) as the two used different versioning syntaxes. This resulted in Forge throwing an error and crashing.

The same error bug was occuring with [Undergarden](https://www.curseforge.com/minecraft/mc-mods/the-undergarden).

I took the liberty of combing through every single dependency and found two more of the same mistake with [Mekanism](https://www.curseforge.com/minecraft/mc-mods/mekanism) and [Mekanism Tools](https://www.curseforge.com/minecraft/mc-mods/mekanism-tools). However, both mods' major versions were higher than Minecraft's. Therefore, Forge considered them within the version range and did not through an error or crash for them. I.e, `10.0.21.448` **∈** `[1.16.5-10.0.21.448,)`. Or, in other words, Forge first compared the major version numbers and found that the Mekanism mods' major version number of **10** is greater than the required version range's of **1**. Hence, because the version range was open, and the mekanism mods both exceeded that minimum value, no error was thrown. ***NEVERTHELESS***, this is still a bug that can cause issues — and one with a simple fix at that — so I went ahead and fixed it. If not fixed, the version range effectively does nothing. For instance, if a user tried to load version 6.0.5.2 of Mekanism, the range would still not catch that as the major version number of 6 is greater than Minecraft's 1.

---

Lastly, I'm not super familiar with *Gradle*, let alone *Curse maven* and *ForgeGradle*. Regardless, I checked the `gradle.build` file and as far as I can tell, Gradle isn't messing with the dependencies in the `mods.toml` file at all, so it doesn't need to be changed. However, if I'm wrong, you may need to change the way you are updating the dependencies in your `mods.toml` file through Gradle.